### PR TITLE
Make compatible with PHP 8

### DIFF
--- a/Classes/Hooks/ShyGuyHook.php
+++ b/Classes/Hooks/ShyGuyHook.php
@@ -25,7 +25,7 @@ class ShyGuyHook
     public function addSoftHyphenInitial($params, &$buttonBar): array
     {
         $buttons = $params['buttons'];
-        $saveButton = $buttons[ButtonBar::BUTTON_POSITION_LEFT][2][0];
+        $saveButton = $buttons[ButtonBar::BUTTON_POSITION_LEFT][2][0] ?? null;
 
         if ($saveButton instanceof InputButton && $saveButton->getName() === '_savedok') {
             $iconFactory = GeneralUtility::makeInstance(IconFactory::class);


### PR DESCRIPTION
I'm currently upgrading a project to PHP 8.1, which uses this extension. At the moment it seems, there must only be done a tiny change for PHP 8 compatibility.

The coalescing operator exists since PHP 7.0, so it is not breaking anything: https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.null-coalesce-op